### PR TITLE
Removing unused code from  views.py

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import render
 from django.http import JsonResponse
 
 from rest_framework.decorators import api_view


### PR DESCRIPTION
## Description

This pull request removes the unnecessary `render` import that is not being used anywhere in the code.

## Changes

- Removed the unused `render` import.

## Checklist

- [ ] Tested the code locally to ensure it still works without the `render` import.
- [ ] Updated relevant documentation if needed.
- [ ] Reviewed and confirmed that the `render` import is not used elsewhere.
- [ ] Ran any relevant code linting or formatting tools.
- [ ] Rebased the branch on the latest upstream changes.
- [ ] Resolved any merge conflicts that may arise.